### PR TITLE
chore: Update db migrations

### DIFF
--- a/db/migrations/20230912115652_modify_users_memberships_table.sql
+++ b/db/migrations/20230912115652_modify_users_memberships_table.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+ALTER TABLE users_memberships ADD trainer_id INT DEFAULT NULL AFTER membership_id;
+ALTER TABLE users_memberships ADD CONSTRAINT users_memberships_trainer_id_fkey
+FOREIGN KEY (trainer_id) REFERENCES users (id);
+
+ALTER TABLE users_memberships DROP FOREIGN KEY users_memberships_user_id_fkey;
+ALTER TABLE users_memberships CHANGE user_id member_id INT NOT NULL;
+ALTER TABLE users_memberships ADD CONSTRAINT users_memberships_member_id_fkey
+FOREIGN KEY (member_id) REFERENCES users (id);
+
+-- migrate:down
+ALTER TABLE users_memberships DROP FOREIGN KEY users_memberships_member_id_fkey;
+ALTER TABLE users_memberships CHANGE member_id user_id INT;
+
+ALTER TABLE users_memberships DROP FOREIGN KEY users_memberships_trainer_id_fkey;
+ALTER TABLE users_memberships DROP trainer_id;

--- a/db/migrations/20230912133154_modify_users_memberships_table.sql
+++ b/db/migrations/20230912133154_modify_users_memberships_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE users_memberships MODIFY start_date DATE NULL;
+ALTER TABLE users_memberships MODIFY end_date DATE NULL;
+
+-- migrate:down
+ALTER TABLE users_memberships MODIFY end_date DATE NOT NULL;
+ALTER TABLE users_memberships MODIFY start_date DATE NOT NULL;

--- a/db/migrations/20230912134327_create_payments_method_table.sql
+++ b/db/migrations/20230912134327_create_payments_method_table.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+CREATE TABLE payments_method (
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+	method VARCHAR(100) NOT NULL
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS payments_method;

--- a/db/migrations/20230912135057_modify_payments_table.sql
+++ b/db/migrations/20230912135057_modify_payments_table.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+ALTER TABLE payments ADD payments_method_id INT NOT NULL AFTER membership_id;
+ALTER TABLE payments ADD CONSTRAINT payments_payments_method_id_fkey
+FOREIGN KEY (payments_method_id) REFERENCES payments_method (id);
+
+-- migrate:down
+ALTER TABLE payments DROP FOREIGN KEY payments_payments_method_id_fkey;
+ALTER TABLE payments DROP payments_method_id;

--- a/db/migrations/20230912141417_modify_trainer_profiles_table.sql
+++ b/db/migrations/20230912141417_modify_trainer_profiles_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE trainer_profiles DROP career;
+ALTER TABLE trainer_profiles DROP license;
+ALTER TABLE trainer_profiles DROP awards;
+
+-- migrate:down
+ALTER TABLE trainer_profiles ADD award VARCHAR(500) DEFAULT NULL;
+ALTER TABLE trainer_profiles ADD license VARCHAR(500) NOT NULL;
+ALTER TABLE trainer_profiles ADD career VARCHAR(500) NOT NULL;

--- a/db/migrations/20230912142017_create_trainer_careers_table.sql
+++ b/db/migrations/20230912142017_create_trainer_careers_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+CREATE TABLE trainer_careers (
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  trainer_profile_id INT NOT NULL,
+  content VARCHAR(500) NOT NULL,
+  CONSTRAINT trainer_careers_trainer_profile_id_fkey FOREIGN KEY (trainer_profile_id) REFERENCES trainer_profiles (id)
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS trainer_careers;

--- a/db/migrations/20230912142027_create_trainer_licenses_table.sql
+++ b/db/migrations/20230912142027_create_trainer_licenses_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+CREATE TABLE trainer_licenses (
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  trainer_profile_id INT NOT NULL,
+  content VARCHAR(500) NOT NULL,
+  CONSTRAINT trainer_licenses_trainer_profile_id_fkey FOREIGN KEY (trainer_profile_id) REFERENCES trainer_profiles (id)
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS trainer_licenses;

--- a/db/migrations/20230912142037_create_trainer_awards_table.sql
+++ b/db/migrations/20230912142037_create_trainer_awards_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+CREATE TABLE trainer_awards (
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  trainer_profile_id INT NOT NULL,
+  content VARCHAR(500) NOT NULL,
+  CONSTRAINT trainer_awards_trainer_profile_id_fkey FOREIGN KEY (trainer_profile_id) REFERENCES trainer_profiles (id)
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS trainer_awards;

--- a/db/migrations/20230913070328_rename_users_memberships_table.sql
+++ b/db/migrations/20230913070328_rename_users_memberships_table.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+RENAME TABLE users_memberships TO members_memberships;
+
+-- migrate:down
+RENAME TABLE members_memberships TO users_memberships;
+

--- a/db/migrations/20230913071145_modify_members_memberships_table.sql
+++ b/db/migrations/20230913071145_modify_members_memberships_table.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+ALTER TABLE members_memberships DROP FOREIGN KEY users_memberships_member_id_fkey;
+ALTER TABLE members_memberships DROP FOREIGN KEY users_memberships_membership_id_fkey;
+ALTER TABLE members_memberships DROP FOREIGN KEY users_memberships_trainer_id_fkey;
+
+ALTER TABLE members_memberships ADD CONSTRAINT members_memberships_member_id_fkey
+FOREIGN KEY (member_id) REFERENCES users (id);
+ALTER TABLE members_memberships ADD CONSTRAINT members_memberships_membership_id_fkey
+FOREIGN KEY (membership_id) REFERENCES memberships (id);
+ALTER TABLE members_memberships ADD CONSTRAINT members_memberships_trainer_id_fkey
+FOREIGN KEY (trainer_id) REFERENCES users (id);
+
+-- migrate:down
+ALTER TABLE members_memberships DROP FOREIGN KEY members_memberships_member_id_fkey;
+ALTER TABLE members_memberships DROP FOREIGN KEY members_memberships_membership_id_fkey;
+ALTER TABLE members_memberships DROP FOREIGN KEY members_memberships_trainer_id_fkey;
+
+ALTER TABLE members_memberships ADD CONSTRAINT users_memberships_member_id_fkey
+FOREIGN KEY (member_id) REFERENCES users (id);
+ALTER TABLE members_memberships ADD CONSTRAINT users_memberships_membership_id_fkey
+FOREIGN KEY (membership_id) REFERENCES memberships (id);
+ALTER TABLE members_memberships ADD CONSTRAINT users_memberships_trainer_id_fkey
+FOREIGN KEY (trainer_id) REFERENCES users (id);


### PR DESCRIPTION
## 스키마 수정사항
- users_memberships 테이블 → start_data, end_date DEFAULT NULL
    - 결제시 payments 테이블과 users_memberships 테이블에 같이 데이터 INSERT
    - start_date를 정할 수 있는 일주일 동안에도 유료 회원이기 때문에 이를 판별하는 것이 필요
- users_memberships 테이블 (trainer_id 컬럼추가)
- trainer_profiles 테이블 정규화
- [career, license, award] 컬럼 삭제 → [trainer_careers, trainer_licenses, trainer_awards] 테이블 생성
- payments 테이블 컬럼추가(payments_method_id) 및 payments_method 테이블 생성, 정규화 (결제수단 확장성 위함)
- users_memberships → members_memberships 테이블명 변경