### PR TITLE
feat: Add API for getting trainer list without unit test code

### DIFF
--- a/api/models/trainerDao.js
+++ b/api/models/trainerDao.js
@@ -7,6 +7,7 @@ const getTrainerList = async (offset, pageSize) => {
       SELECT
         u.id,
         tg.emoji,
+        tg.name emojiName,
         u.nickname nickName,
         u.profile_image profileImage,
         tp.score,


### PR DESCRIPTION
## 수정사항

- 이모지 자체를 string 형식으로 직접 response -> 이모지 name값을 response, 프론트에서 분기처리 (프론트와 회의 완료하였음)
